### PR TITLE
Add localisation capability to support other languages

### DIFF
--- a/MMM-birthdays.js
+++ b/MMM-birthdays.js
@@ -9,13 +9,15 @@ Module.register("MMM-birthdays", {
         notify_days_before: 14,
         update_interval: 600,
         display_dates: null,
+        title: null,
         opacity: true,
         locale: "en_GB",
     },
 
     socketNotificationReceived: function (notification, payload) {
         if (notification === "RECV_BIRTHDAYS") {
-            this.config.display_dates = payload;
+            this.config.display_dates = payload.birthdays;
+            this.config.title = payload.title;
             this.getDom();
         }
 
@@ -27,7 +29,7 @@ Module.register("MMM-birthdays", {
         wrapper.className = "module-content";
 
         wrapper.innerHTML = `
-            <header class="module-header">BIRTHDAYS</header>
+            <header class="module-header">${this.config.title}</header>
         `
 
         var table = document.createElement("table");

--- a/MMM-birthdays.js
+++ b/MMM-birthdays.js
@@ -37,7 +37,7 @@ Module.register("MMM-birthdays", {
 
         if (this.config.display_dates !== null) {
             wrapper.innerHTML += `
-                <table class="small>
+                <table class="small">
                     <tbody>
             `
 

--- a/MMM-birthdays.js
+++ b/MMM-birthdays.js
@@ -10,6 +10,7 @@ Module.register("MMM-birthdays", {
         update_interval: 600,
         display_dates: null,
         opacity: true,
+        locale: "en_GB",
     },
 
     socketNotificationReceived: function (notification, payload) {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This module is intended to be extremely simple to use and therefore only provide
 | notify_days_before  | Number of days before birthday that notifications should start to be shown - any value greater than 365 will be floored to 365. Set to 0 to only show birthdays on the day  | 14  |
 | update_internal  | Number of seconds between updating displayed birthdays  | 600  |
 | opacity  | A boolean option to indicate whether subsequent birthday rows beyond three should fade out (think weather forecast module) or not | true  |
+| locale  | A string used to set language for module (not case-sensitive):<br /><br />English: `en_GB` <br />German: `de_DE` | `en_GB`  |
 | birthdays  | An array of `birthdays` objects as described below | See below  |
 
 So, the default `config.js` entry for this module could look like this:
@@ -28,6 +29,7 @@ So, the default `config.js` entry for this module could look like this:
         notify_days_before: 14,
         update_interval: 600,
         opacity: true,
+        locale: "en_GB",
     }
 }
 ```
@@ -49,6 +51,8 @@ As this is an array, it can contain multiple `birthdays` objects. The example be
     config: {
         notify_days_before: 14,
         update_interval: 600,
+        opacity: true,
+        locale: "en_GB",
         birthdays: [
             {
                 name: "Adam",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A birthday reminder module for MichMich's [MagicMirror](https://magicmirror.buil
 ![Screenshot](https://github.com/amitchone/MMM-birthdays/blob/screenshot/MMM-birthdays_screenshot.png "Screenshot")
 
 ## Installation
-- Navigate to your MagicMirror `modules` folder and clone this repository using: `https://github.com/amitchone/MMM-birthdays.git`
+- Navigate to your MagicMirror `modules` folder and clone this repository using: `git clone https://github.com/amitchone/MMM-birthdays.git`
 - Change directory to `MMM-birthdays` via `cd MMM-birthdays/`
 - Run `npm install` to install the necessary third-party packages
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module is intended to be extremely simple to use and therefore only provide
 | notify_days_before  | Number of days before birthday that notifications should start to be shown - any value greater than 365 will be floored to 365. Set to 0 to only show birthdays on the day  | 14  |
 | update_internal  | Number of seconds between updating displayed birthdays  | 600  |
 | opacity  | A boolean option to indicate whether subsequent birthday rows beyond three should fade out (think weather forecast module) or not | true  |
-| locale  | A string used to set language for module (not case-sensitive):<br /><br />English: `en_GB` <br />German: `de_DE` | `en_GB`  |
+| locale  | A string used to set language for module (not case-sensitive):<br /><br />English: `en_GB` <br />French: `fr_FR` <br />German: `de_DE` <br />Spanish: `es_ES` | `en_GB`  |
 | birthdays  | An array of `birthdays` objects as described below | See below  |
 
 So, the default `config.js` entry for this module could look like this:

--- a/locales/de_de.json
+++ b/locales/de_de.json
@@ -1,0 +1,10 @@
+{
+    "title": "GEBURTSTAGE",
+    "phrase": {
+        "u_m": "{NAME} wird in {DAYS} Tagen {AGE}",
+        "u_s": "{NAME} wird in {DAYS} Tag {AGE} sein",
+        "p_m": "{NAME} war vor {DAYS} Tag {AGE} Jahre alt",
+        "p_s": "{NAME} war vor {DAYS} Tagen {AGE}",
+        "t": "{NAME} ist heute {AGE}!"
+    }
+}

--- a/locales/de_de.json
+++ b/locales/de_de.json
@@ -1,10 +1,10 @@
 {
     "title": "GEBURTSTAGE",
     "phrase": {
-        "u_m": "{NAME} wird in {DAYS} Tagen {AGE}",
+        "u_m": "{NAME} wird in {DAYS} Tagen {AGE}",        
         "u_s": "{NAME} wird in {DAYS} Tag {AGE} sein",
-        "p_m": "{NAME} war vor {DAYS} Tag {AGE} Jahre alt",
-        "p_s": "{NAME} war vor {DAYS} Tagen {AGE}",
-        "t": "{NAME} ist heute {AGE}!"
+        "p_m": "{NAME} wurde vor {DAYS} Tagen {AGE} Jahre alt",
+        "p_s": "{NAME} wurde vor {DAYS} Tag {AGE}",
+        "t": "{NAME} wird heute {AGE}!"
     }
 }

--- a/locales/en_GB.json
+++ b/locales/en_GB.json
@@ -1,0 +1,9 @@
+{
+    "title": "Birthdays",
+    "phrase": {
+        "u_m": "{NAME} will be {AGE} in {DAYS} days",
+        "u_s": "{NAME} will be {AGE} in 1 day",
+        "p_m": "{NAME} was {AGE} {DAYS} ago",
+        "p_s": "{NAME} was {AGE} 1 day ago"
+    }
+}

--- a/locales/en_GB.json
+++ b/locales/en_GB.json
@@ -1,9 +1,0 @@
-{
-    "title": "Birthdays",
-    "phrase": {
-        "u_m": "{NAME} will be {AGE} in {DAYS} days",
-        "u_s": "{NAME} will be {AGE} in 1 day",
-        "p_m": "{NAME} was {AGE} {DAYS} ago",
-        "p_s": "{NAME} was {AGE} 1 day ago"
-    }
-}

--- a/locales/en_gb.json
+++ b/locales/en_gb.json
@@ -4,6 +4,7 @@
         "u_m": "{NAME} will be {AGE} in {DAYS} days",
         "u_s": "{NAME} will be {AGE} in 1 day",
         "p_m": "{NAME} was {AGE} {DAYS} ago",
-        "p_s": "{NAME} was {AGE} 1 day ago"
+        "p_s": "{NAME} was {AGE} 1 day ago",
+        "t": "{NAME} is {AGE} today!"
     }
 }

--- a/locales/en_gb.json
+++ b/locales/en_gb.json
@@ -1,0 +1,9 @@
+{
+    "title": "BIRTHDAYS",
+    "phrase": {
+        "u_m": "{NAME} will be {AGE} in {DAYS} days",
+        "u_s": "{NAME} will be {AGE} in 1 day",
+        "p_m": "{NAME} was {AGE} {DAYS} ago",
+        "p_s": "{NAME} was {AGE} 1 day ago"
+    }
+}

--- a/locales/en_gb.json
+++ b/locales/en_gb.json
@@ -2,9 +2,9 @@
     "title": "BIRTHDAYS",
     "phrase": {
         "u_m": "{NAME} will be {AGE} in {DAYS} days",
-        "u_s": "{NAME} will be {AGE} in 1 day",
+        "u_s": "{NAME} will be {AGE} in {DAYS} day",
         "p_m": "{NAME} was {AGE} {DAYS} ago",
-        "p_s": "{NAME} was {AGE} 1 day ago",
+        "p_s": "{NAME} was {AGE} {DAYS} day ago",
         "t": "{NAME} is {AGE} today!"
     }
 }

--- a/locales/es_es.json
+++ b/locales/es_es.json
@@ -1,0 +1,10 @@
+{
+    "title": "CUMPLEAÑOS",
+    "phrase": {
+        "u_m": "{NAME} cumplirá {AGE} años en {DAYS} días",
+        "u_s": "{NAME} cumplirá {AGE} años en {DAYS} día",
+        "p_m": "{NAME} tenía {AGE} años hace {DAYS} días",
+        "p_s": "{NAME} tenía {AGE} años hace {DAYS} día",
+        "t": "¡{NAME} cumple {AGE} años hoy!"
+    }
+}

--- a/locales/fr_fr.json
+++ b/locales/fr_fr.json
@@ -1,0 +1,10 @@
+{
+    "title": "ANNIVERSAIRES",
+    "phrase": {
+        "u_m": "{NAME} aura {AGE} ans dans {DAYS} jours",
+        "u_s": "{NAME} aura {AGE} ans dans {DAYS} jour",
+        "p_m": "{NAME} avait {AGE} ans il y a {DAYS} jours",
+        "p_s": "{NAME} avait {AGE} ans il y a {DAYS} jour",
+        "t": "{NAME} a {AGE} ans aujourd'hui !"
+    }
+}

--- a/node_helper.js
+++ b/node_helper.js
@@ -10,9 +10,25 @@ module.exports = NodeHelper.create({
         this.config = payload;
 
 		if (notification === "GET_BIRTHDAYS") {
+            this.config.loc_data = this.get_locale(this.config.locale);
 			this.get_birthdays(this.config);
 		}
 	},
+
+    get_locale: function (locale) {
+        var loc_data;
+
+        try {
+            console.log(`mmm-birthdays: using locale ${locale}`);
+            loc_data = JSON.parse(fs.readFileSync(`${__dirname}/locales/${String(locale).toLowerCase()}.json`), "utf-8");
+        }
+        catch (e) {
+            console.log(`mmm-birthdays: locale ${locale} is not supported, falling back to en_GB`);
+            loc_data = JSON.parse(fs.readFileSync(`${__dirname}/locales/en_gb.json`), "utf-8");
+        }
+        
+        return loc_data;
+    },
 
     get_birthdays: function () {
         var birthdays = null;

--- a/node_helper.js
+++ b/node_helper.js
@@ -97,9 +97,14 @@ module.exports = NodeHelper.create({
                 }
             }
             else if (dtb == 0) {
+                var who = this.config.loc_data.phrase.t;
+
+                who = String(who).replace("{NAME}", name);
+                who = String(who).replace("{AGE}", cur_age);
+
                 display_birthdays.push({
                     "ord": dtb,
-                    "who": `${name} is ${cur_age} today!`,
+                    "who": who
                 });
                 
                 console.log(`mmm-birthdays: ${name} is ${cur_age} today!`)

--- a/node_helper.js
+++ b/node_helper.js
@@ -114,7 +114,7 @@ module.exports = NodeHelper.create({
         if (display_birthdays.length > 0) {
             display_birthdays.sort((a, b) => a.ord - b.ord);
 
-            this.sendSocketNotification("RECV_BIRTHDAYS", display_birthdays);
+            this.sendSocketNotification("RECV_BIRTHDAYS", {birthdays: display_birthdays, title: this.config.loc_data.title});
         }
     },
 });

--- a/node_helper.js
+++ b/node_helper.js
@@ -82,15 +82,18 @@ module.exports = NodeHelper.create({
 
             if (dtb > 0) {
                 if (dtb <= this.config.notify_days_before) {
-                    var days = "day"
-                    if (dtb > 1) days += "s"
+                    var who = (dtb > 1) ? this.config.loc_data.phrase.u_m : this.config.loc_data.phrase.u_s;
+
+                    who = String(who).replace("{NAME}", name);
+                    who = String(who).replace("{AGE}", new_age);
+                    who = String(who).replace("{DAYS}", dtb);
 
                     display_birthdays.push({
                         "ord": dtb,
-                        "who": `${name} will be ${new_age} in ${dtb} ${days}`,
+                        "who": who
                     });
 
-                    console.log(`mmm-birthdays: ${name} will be ${new_age} in ${dtb} ${days}`)
+                    console.log(`mmm-birthdays: ${who}`)
                 }
             }
             else if (dtb == 0) {


### PR DESCRIPTION
Add support for JSON files in _locales/_ that contain key phrases in different languages to allow easy localisation for users requiring support for languages other than English - currently supports English, German, French, and Spanish.

Closes #2 